### PR TITLE
Make chunk size in the table definition dynamic

### DIFF
--- a/pganonymizer/constants.py
+++ b/pganonymizer/constants.py
@@ -9,3 +9,6 @@ COPY_DB_DELIMITER = '\x1f'
 
 # Filename of the default schema
 DEFAULT_SCHEMA_FILE = 'schema.yml'
+
+# Default chunk size for data fetch
+DEFAULT_CHUNK_SIZE = 2000

--- a/pganonymizer/utils.py
+++ b/pganonymizer/utils.py
@@ -14,7 +14,7 @@ from progress.bar import IncrementalBar
 from psycopg2.errors import BadCopyFileFormat, InvalidTextRepresentation
 from six import StringIO
 
-from pganonymizer.constants import COPY_DB_DELIMITER, DEFAULT_PRIMARY_KEY
+from pganonymizer.constants import COPY_DB_DELIMITER, DEFAULT_PRIMARY_KEY, DEFAULT_CHUNK_SIZE
 from pganonymizer.exceptions import BadDataFormat
 from pganonymizer.providers import get_provider
 
@@ -37,11 +37,12 @@ def anonymize_tables(connection, definitions, verbose=False):
         column_dict = get_column_dict(columns)
         primary_key = table_definition.get('primary_key', DEFAULT_PRIMARY_KEY)
         total_count = get_table_count(connection, table_name)
-        data, table_columns = build_data(connection, table_name, columns, excludes, search, total_count, verbose)
+        chunk_size = table_definition.get('chunk_size', DEFAULT_CHUNK_SIZE)
+        data, table_columns = build_data(connection, table_name, columns, excludes, search, total_count, chunk_size, verbose)
         import_data(connection, column_dict, table_name, table_columns, primary_key, data)
 
 
-def build_data(connection, table, columns, excludes, search, total_count, verbose=False):
+def build_data(connection, table, columns, excludes, search, total_count, chunk_size, verbose=False):
     """
     Select all data from a table and return it together with a list of table columns.
 
@@ -67,7 +68,7 @@ def build_data(connection, table, columns, excludes, search, total_count, verbos
     data = []
     table_columns = None
     while True:
-        records = cursor.fetchmany(size=2000)
+        records = cursor.fetchmany(size=chunk_size)
         if not records:
             break
         for row in records:

--- a/sample_schema.yml
+++ b/sample_schema.yml
@@ -1,6 +1,7 @@
 tables:
  - auth_user:
     primary_key: id
+    chunk_size: 5000
     fields:
      - first_name:
         provider:


### PR DESCRIPTION
Chunk size used while fetching data from source was hardcoded. I needed to change it according to the needs per table. This PR makes it dynamic in the schema definition.