### PR TITLE
Fix table and column name quotes in cursor.copy_from call

### DIFF
--- a/pganonymizer/utils.py
+++ b/pganonymizer/utils.py
@@ -81,7 +81,7 @@ def build_data(connection, table, columns, excludes, search, total_count, chunk_
                     row[key] = value
             if verbose:
                 progress_bar.next()
-            table_columns = ['"{}"'.format(column) for column in row.keys()]
+            table_columns = [column for column in row.keys()]
             if not row_column_dict:
                 continue
             data.append(row.values())
@@ -145,9 +145,9 @@ def import_data(connection, column_dict, source_table, table_columns, primary_ke
     :param list data: The table data.
     """
     primary_key = primary_key if primary_key else DEFAULT_PRIMARY_KEY
-    temp_table = '"tmp_{table}"'.format(table=source_table)
+    temp_table = 'tmp_{table}'.format(table=source_table)
     cursor = connection.cursor()
-    cursor.execute('CREATE TEMP TABLE %s (LIKE %s INCLUDING ALL) ON COMMIT DROP;' % (temp_table, source_table))
+    cursor.execute('CREATE TEMP TABLE "%s" (LIKE %s INCLUDING ALL) ON COMMIT DROP;' % (temp_table, source_table))
     copy_from(connection, data, temp_table, table_columns)
     set_columns = ', '.join(['{column} = s.{column}'.format(column='"{}"'.format(key)) for key in column_dict.keys()])
     sql = (

--- a/pganonymizer/utils.py
+++ b/pganonymizer/utils.py
@@ -126,7 +126,7 @@ def copy_from(connection, data, table, columns):
     new_data = data2csv(data)
     cursor = connection.cursor()
     try:
-        cursor.copy_from(new_data, table, sep=COPY_DB_DELIMITER, null='\\N', columns=columns)
+        cursor.copy_from(new_data, table, sep=COPY_DB_DELIMITER, null='\\N', columns=['"{}"'.format(column) for column in columns])
     except (BadCopyFileFormat, InvalidTextRepresentation) as exc:
         raise BadDataFormat(exc)
     cursor.close()

--- a/pganonymizer/utils.py
+++ b/pganonymizer/utils.py
@@ -126,7 +126,8 @@ def copy_from(connection, data, table, columns):
     new_data = data2csv(data)
     cursor = connection.cursor()
     try:
-        cursor.copy_from(new_data, table, sep=COPY_DB_DELIMITER, null='\\N', columns=['"{}"'.format(column) for column in columns])
+        quoted_cols = ['"{}"'.format(column) for column in columns]
+        cursor.copy_from(new_data, table, sep=COPY_DB_DELIMITER, null='\\N', columns=quoted_cols)
     except (BadCopyFileFormat, InvalidTextRepresentation) as exc:
         raise BadDataFormat(exc)
     cursor.close()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import pytest
 from mock import ANY, Mock, call, patch
 
-from pganonymizer.utils import get_connection, truncate_tables, import_data
+from pganonymizer.utils import get_connection, import_data, truncate_tables
 
 
 class TestGetConnection:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -43,7 +43,7 @@ class TestTruncateTables:
 class TestImportData:
 
     @pytest.mark.parametrize('source_table, table_columns, primary_key, expected_tbl_name, expected_columns', [
-        [{'FOO': None}, 'src_tbl', ['id', 'COL_1'], 'id', 'tmp_src_tbl', ['"id"', '"COL_1"']]
+        ['src_tbl', ['id', 'COL_1'], 'id', 'tmp_src_tbl', ['"id"', '"COL_1"']]
     ])
     def test(self, source_table, table_columns, primary_key, expected_tbl_name, expected_columns):
         mock_cursor = Mock()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -42,19 +42,20 @@ class TestTruncateTables:
 
 class TestImportData:
 
-    @pytest.mark.parametrize('column_dict, source_table, table_columns, primary_key, data, expected_tbl_name, expected_columns', [
-        [{'FOO': None}, 'src_tbl', ['id', 'COL_1'], 'id', [], 'tmp_src_tbl', ['"id"', '"COL_1"'] ]
+    @pytest.mark.parametrize('column_dict, source_table, table_columns, primary_key, expected_tbl_name, expected_columns', [
+        [{'FOO': None}, 'src_tbl', ['id', 'COL_1'], 'id', 'tmp_src_tbl', ['"id"', '"COL_1"']]
     ])
-    def test(self, column_dict, source_table, table_columns, primary_key, data, expected_tbl_name, expected_columns):
+    def test(self, column_dict, source_table, table_columns, primary_key, expected_tbl_name, expected_columns):
         mock_cursor = Mock()
 
         connection = Mock()
         connection.cursor.return_value = mock_cursor
 
-        import_data(connection, column_dict, source_table, table_columns, primary_key, data)
-       
+        import_data(connection, column_dict, source_table, table_columns, primary_key, [])
+
         assert connection.cursor.call_count == 2
         assert mock_cursor.close.call_count == 2
 
         mock_cursor.copy_from.assert_called_once()
-        assert mock_cursor.copy_from.call_args_list == [call(ANY, expected_tbl_name, columns=expected_columns, null=ANY, sep=ANY)]
+        expected = [call(ANY, expected_tbl_name, columns=expected_columns, null=ANY, sep=ANY)]
+        assert mock_cursor.copy_from.call_args_list == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -42,10 +42,10 @@ class TestTruncateTables:
 
 class TestImportData:
 
-    @pytest.mark.parametrize('column_dict, source_table, table_columns, primary_key, data, expected_tbl_name', [
-        [{'foo': None}, 'src_tbl', ['id', 'col1'], 'id', [], 'tmp_src_tbl' ]
+    @pytest.mark.parametrize('column_dict, source_table, table_columns, primary_key, data, expected_tbl_name, expected_columns', [
+        [{'FOO': None}, 'src_tbl', ['id', 'COL_1'], 'id', [], 'tmp_src_tbl', ['"id"', '"COL_1"'] ]
     ])
-    def test(self, column_dict, source_table, table_columns, primary_key, data, expected_tbl_name):
+    def test(self, column_dict, source_table, table_columns, primary_key, data, expected_tbl_name, expected_columns):
         mock_cursor = Mock()
 
         connection = Mock()
@@ -57,4 +57,4 @@ class TestImportData:
         assert mock_cursor.close.call_count == 2
 
         mock_cursor.copy_from.assert_called_once()
-        assert mock_cursor.copy_from.call_args_list == [call(ANY, expected_tbl_name, columns=ANY, null=ANY, sep=ANY)]
+        assert mock_cursor.copy_from.call_args_list == [call(ANY, expected_tbl_name, columns=expected_columns, null=ANY, sep=ANY)]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -42,16 +42,16 @@ class TestTruncateTables:
 
 class TestImportData:
 
-    @pytest.mark.parametrize('column_dict, source_table, table_columns, primary_key, expected_tbl_name, expected_columns', [
+    @pytest.mark.parametrize('source_table, table_columns, primary_key, expected_tbl_name, expected_columns', [
         [{'FOO': None}, 'src_tbl', ['id', 'COL_1'], 'id', 'tmp_src_tbl', ['"id"', '"COL_1"']]
     ])
-    def test(self, column_dict, source_table, table_columns, primary_key, expected_tbl_name, expected_columns):
+    def test(self, source_table, table_columns, primary_key, expected_tbl_name, expected_columns):
         mock_cursor = Mock()
 
         connection = Mock()
         connection.cursor.return_value = mock_cursor
 
-        import_data(connection, column_dict, source_table, table_columns, primary_key, [])
+        import_data(connection, {}, source_table, table_columns, primary_key, [])
 
         assert connection.cursor.call_count == 2
         assert mock_cursor.close.call_count == 2


### PR DESCRIPTION
Hi, it seems like [this](https://github.com/rheinwerk-verlag/postgresql-anonymizer/commit/f181cb5f2aa2824ce9ec5e043e58a19ebbe13533) commit introduced regression when table name and columns had been quoted like `'tbl_name'`, this caused issue in `copy_from`, when calling `cursor.copy_from`. This PR fixes it
