### PR TITLE
Remove column specification for cursor.copy_from call

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -42,20 +42,20 @@ class TestTruncateTables:
 
 class TestImportData:
 
-    @pytest.mark.parametrize('source_table, table_columns, primary_key, expected_tbl_name, expected_columns', [
-        ['src_tbl', ['id', 'COL_1'], 'id', 'tmp_src_tbl', ['"id"', '"COL_1"']]
+    @pytest.mark.parametrize('source_table, primary_key, expected_tbl_name', [
+        ['src_tbl', 'id', 'tmp_src_tbl']
     ])
-    def test(self, source_table, table_columns, primary_key, expected_tbl_name, expected_columns):
+    def test(self, source_table, primary_key, expected_tbl_name):
         mock_cursor = Mock()
 
         connection = Mock()
         connection.cursor.return_value = mock_cursor
 
-        import_data(connection, {}, source_table, table_columns, primary_key, [])
+        import_data(connection, {}, source_table, primary_key, [])
 
         assert connection.cursor.call_count == 2
         assert mock_cursor.close.call_count == 2
 
         mock_cursor.copy_from.assert_called_once()
-        expected = [call(ANY, expected_tbl_name, columns=expected_columns, null=ANY, sep=ANY)]
+        expected = [call(ANY, expected_tbl_name, null=ANY, sep=ANY)]
         assert mock_cursor.copy_from.call_args_list == expected


### PR DESCRIPTION
Hi! This [commit](https://github.com/rheinwerk-verlag/postgresql-anonymizer/commit/9b174d53626c3ed5de78617d23340b994dfbc342) causes error on my db (aws rds, default config, PostgreSQL 12.6)

And if I revert this commit, it will definitely cause problems discussed [here](https://github.com/rheinwerk-verlag/postgresql-anonymizer/pull/22#issuecomment-871189766)

So, obvious solution is to remove this parameter at all :)

[copy_from  doc](https://www.psycopg.org/docs/cursor.html#cursor.copy_from)

> columns – iterable with name of the columns to import. The length and types should match the content of the file to read. If not specified, it is assumed that the entire table matches the file structure.

We can be sure that data matches table structure, because we're using `DictCursor` which underlying uses [OrderedDict](https://github.com/psycopg/psycopg2/blob/1d3a89a0bba621dc1cc9b32db6d241bd2da85ad1/lib/extras.py#L144)

