### PR TITLE
Fix batch processing

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,8 @@
-import pytest
+import math
 from mock import ANY, Mock, call, patch
+import pytest
 
-from pganonymizer.utils import get_connection, import_data, truncate_tables
+from pganonymizer.utils import build_and_then_import_data, get_connection, import_data, truncate_tables
 
 
 class TestGetConnection:
@@ -59,3 +60,32 @@ class TestImportData:
         mock_cursor.copy_from.assert_called_once()
         expected = [call(ANY, expected_tbl_name, null=ANY, sep=ANY)]
         assert mock_cursor.copy_from.call_args_list == expected
+
+
+class TestBuildAndThenImport:
+    @pytest.mark.parametrize('table, primary_key, columns, total_count, chunk_size, expected_callcount', [
+        ['src_tbl', 'id', [{'col1': {'provider': None}}, {'COL2': {'provider': None}}], 10, 3, 4]
+    ])
+    def test(self, table, primary_key, columns, total_count, chunk_size, expected_callcount):
+        fake_record = dict.fromkeys([list(definition.keys())[0] for definition in columns], "")
+        records = [
+            [fake_record for row in range(0, chunk_size)] for x in range(0, int(math.ceil(total_count / chunk_size)))
+        ]
+
+        def side_effect(size=None):
+            if len(records) >= 1:
+                return records.pop()
+            else:
+                return None
+
+        mock_cursor = Mock()
+        mock_cursor.fetchmany.side_effect = side_effect
+
+        connection = Mock()
+        connection.cursor.return_value = mock_cursor
+
+        build_and_then_import_data(connection, table, primary_key, columns, None, None, total_count, chunk_size)
+
+        assert connection.cursor.call_count == 9
+        assert mock_cursor.close.call_count == 9
+        assert mock_cursor.copy_from.call_count == expected_callcount

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -42,20 +42,20 @@ class TestTruncateTables:
 
 class TestImportData:
 
-    @pytest.mark.parametrize('source_table, table_columns, primary_key, expected_tbl_name, expected_columns', [
-        ['src_tbl', ['id', 'COL_1'], 'id', 'tmp_src_tbl', ['"id"', '"COL_1"']]
+    @pytest.mark.parametrize('source_table, primary_key, expected_tbl_name', [
+        ['src_tbl', 'id', 'tmp_src_tbl']
     ])
-    def test(self, source_table, table_columns, primary_key, expected_tbl_name, expected_columns):
+    def test(self, source_table, primary_key, expected_tbl_name):
         mock_cursor = Mock()
 
         connection = Mock()
         connection.cursor.return_value = mock_cursor
 
-        import_data(connection, {}, source_table, table_columns, primary_key, [])
+        import_data(connection, {}, source_table, primary_key, [])
 
         assert connection.cursor.call_count == 2
         assert mock_cursor.close.call_count == 2
 
         mock_cursor.copy_from.assert_called_once()
-        expected = [call(ANY, expected_tbl_name, columns=expected_columns, null=ANY, sep=ANY)]
+        expected = [call(ANY, expected_tbl_name, null=ANY, sep=ANY)]
         assert mock_cursor.copy_from.call_args_list == expected


### PR DESCRIPTION
This pr fixes issue with processing huge tables. It calls `import_data` inside loop that calls `fetchmany` and clears `data` and  StringIO buffers after each iteration

Depends on https://github.com/rheinwerk-verlag/postgresql-anonymizer/pull/25